### PR TITLE
Use named return values

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,12 +2,13 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/mitchellh/go-homedir"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"kubeconnect/k8s"
 	"kubeconnect/lib"
 	"os"
+
+	"github.com/mitchellh/go-homedir"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var cfgFile string
@@ -23,22 +24,19 @@ This application is a tool to generate the needed files
 to quickly create a Cobra application.`,
 	// Uncomment the following line if your bare application
 	// has an action associated with it:
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		context, err := getContext()
 		if err != nil {
-			fmt.Print(err.Error())
 			return
 		}
 
 		namespace, err := getNamespace(context)
 		if err != nil {
-			fmt.Print(err.Error())
 			return
 		}
 
 		pod, err := getPod(context, namespace)
 		if err != nil {
-			fmt.Print(err.Error())
 			return
 		}
 
@@ -48,7 +46,7 @@ to quickly create a Cobra application.`,
 		// Get the current working directory.
 		cwd, err := os.Getwd()
 		if err != nil {
-			panic(err)
+			return
 		}
 
 		// Transfer stdin, stdout, and stderr to the new process
@@ -63,14 +61,13 @@ to quickly create a Cobra application.`,
 			[]string{"kubectl", "exec", "-it", "--namespace", namespace.Name, "--context", context.Name, pod.Name, "/bin/sh"}, &pa)
 
 		if err != nil {
-			panic(err)
+			return
 		}
 
 		// Wait until user exits the shell
 		_, err = proc.Wait()
-		if err != nil {
-			panic(err)
-		}
+
+		return
 	},
 }
 

--- a/k8s/context.go
+++ b/k8s/context.go
@@ -14,37 +14,34 @@ type Context struct {
 }
 
 // ContextListItems Transform a list of Contexts to a list of ListItems to show in the Selector
-func ContextListItems(contexts []Context) []lib.ListItem {
-	var items []lib.ListItem
-
+func ContextListItems(contexts []Context) (items []lib.ListItem) {
 	for index, context := range contexts {
 		items = append(items, lib.ListItem{Number: index + 1, Label: context.Name})
 	}
 
-	return items
+	return
 }
 
 // GetContexts returns all configured Contexts in kubectl
-func GetContexts() ([]Context, error) {
+func GetContexts() (contexts []Context, err error) {
 	cmd := exec.Command("kubectl", "config", "get-contexts", "-o=name")
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
-	err := cmd.Run()
+	err = cmd.Run()
 	if err != nil {
 		return nil, errors.New(stderr.String())
 	}
 
 	lines := strings.Split(strings.Trim(stdout.String(), "\n"), "\n")
 
-	var contexts []Context
 	for _, name := range lines {
 		if name != "NAME" {
 			contexts = append(contexts, Context{Name: name})
 		}
 	}
 
-	return contexts, nil
+	return
 }

--- a/k8s/namespace.go
+++ b/k8s/namespace.go
@@ -14,32 +14,29 @@ type Namespace struct {
 }
 
 // NamespaceListItems Transforms a list of Namespaces to a list of ListItems to show in the Selector
-func NamespaceListItems(namespaces []Namespace) []lib.ListItem {
-	var items []lib.ListItem
-
+func NamespaceListItems(namespaces []Namespace) (items []lib.ListItem) {
 	for index, namespace := range namespaces {
 		items = append(items, lib.ListItem{Number: index + 1, Label: namespace.Name})
 	}
 
-	return items
+	return
 }
 
 // GetNamespaces returns all namespaces in a given Context
-func GetNamespaces(context Context) ([]Namespace, error) {
+func GetNamespaces(context Context) (namespaces []Namespace, err error) {
 	cmd := exec.Command("kubectl", "get", "ns", "--context", context.Name)
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
-	err := cmd.Run()
+	err = cmd.Run()
 	if err != nil {
 		return nil, errors.New(stderr.String())
 	}
 
 	lines := strings.Split(strings.Trim(stdout.String(), "\n"), "\n")
 
-	var namespaces []Namespace
 	for _, line := range lines {
 		var name = strings.Split(line, " ")[0]
 		if name != "NAME" {
@@ -47,5 +44,5 @@ func GetNamespaces(context Context) ([]Namespace, error) {
 		}
 	}
 
-	return namespaces, nil
+	return
 }

--- a/k8s/pod.go
+++ b/k8s/pod.go
@@ -14,32 +14,29 @@ type Pod struct {
 }
 
 // PodListItems Transforms a list of Pods to a list of ListItems to show in the Selector
-func PodListItems(pods []Pod) []lib.ListItem {
-	var items []lib.ListItem
-
+func PodListItems(pods []Pod) (items []lib.ListItem) {
 	for index, pod := range pods {
 		items = append(items, lib.ListItem{Number: index + 1, Label: pod.Name})
 	}
 
-	return items
+	return
 }
 
 // GetPods returns all Pods in a given Namespace and Context
-func GetPods(context Context, namespace Namespace) ([]Pod, error) {
+func GetPods(context Context, namespace Namespace) (pods []Pod, err error) {
 	cmd := exec.Command("kubectl", "get", "pod", "--context", context.Name, "--namespace", namespace.Name)
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
-	err := cmd.Run()
+	err = cmd.Run()
 	if err != nil {
 		return nil, errors.New(stderr.String())
 	}
 
 	lines := strings.Split(strings.Trim(stdout.String(), "\n"), "\n")
 
-	var pods []Pod
 	for _, line := range lines {
 		var name = strings.Split(line, " ")[0]
 		if name != "NAME" {
@@ -47,5 +44,5 @@ func GetPods(context Context, namespace Namespace) ([]Pod, error) {
 		}
 	}
 
-	return pods, nil
+	return
 }

--- a/lib/selector.go
+++ b/lib/selector.go
@@ -2,8 +2,9 @@ package lib
 
 import (
 	"errors"
-	"github.com/manifoldco/promptui"
 	"strings"
+
+	"github.com/manifoldco/promptui"
 )
 
 // ListItem is a Item that can be displayed in the Selector as a selection item


### PR DESCRIPTION
Just a cosmetic change, using named return values we don't need to redeclare some of the variables on each function and also delegate the returned object to go itself.